### PR TITLE
Update RGBTools.cpp to avoid a color blink

### DIFF
--- a/RGBTools/RGBTools.cpp
+++ b/RGBTools/RGBTools.cpp
@@ -52,7 +52,7 @@ void RGBTools::fadeTo(int r,int g,int b,int steps,int duration){
 	float steps_b = diff_b / steps;
 
 	// loop through the steps
-	for(int i = 0; i < steps; i++){
+	for(int i = 1; i <= steps; i++){
 
 		// set color of current step
 		this->setColor(


### PR DESCRIPTION
Before, when I used fadeTo the led was set for a short amount of time at the final color. Now this is OK.
